### PR TITLE
adds redirect URI back to demo.typekit.io

### DIFF
--- a/js/ims.js
+++ b/js/ims.js
@@ -26,8 +26,6 @@
     uses_debug_mode: true,
     // OTHER FREQUENTLY USED OPTIONS:
     scope: 'tk_platform,tk_platform_mp,tk_platform_sync',
-    locale: 'en_US',
-    ssoLoginUrl: 'https://localhost:8443?handle_sso_login',
-    ssoLogoutUrl: 'https://localhost:8443?handle_sso_logout',
+    locale: 'en_US'
   };
 })();

--- a/partials/header.html
+++ b/partials/header.html
@@ -4,7 +4,7 @@
       <a href="/" title="Adobe Typekit Platform Demo App">Adobe Typekit Platform Demo App</a>
     </div>
     <div class="account" id="notSignedIn" ng-hide="userSignedIn">
-      <div class="account-button" onclick="adobeIMS.signIn()">SIGN IN</div>
+      <div class="account-button" onclick="adobeIMS.signIn({'redirect_uri':'https://demo.typekit.io'})">SIGN IN</div>
       <div class="account-button" onclick="adobeIMS.signUp()">SIGN UP</div>
     </div>
     <div class="account" id="signedIn" ng-show="userSignedIn">


### PR DESCRIPTION
following the sign in ims lib needs to redirect back to the demo app
